### PR TITLE
Changes and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This program allows you to integrate [PiShock](https://pishock.com) devices with
 ## Setup Instructions
 
 1. **Install the newest release.**
-2. **Open the configuration file** (`config.yaml`) in any text editor (VS Code is recommended for clarity).
+2. **Open the configuration file** (`pishock_config.yaml`) and (`archipelago_config.yaml`) in any text editor (VS Code is recommended for clarity).
 3. **Fill out the necessary fields** as described below.
 
 **Important** All ShareCodes must be Claimed for this to work, claim them by going to your PiShock Controll panel, then Click the three lines in bottom left corner and click Shared Code, place your sharecode within there and it should be good.
@@ -22,7 +22,7 @@ This program allows you to integrate [PiShock](https://pishock.com) devices with
 
 ### `archipelago`
 
-Configure your connection to the Archipelago multiworld server.
+Configure your connection to the Archipelago multiworld server. (`archipelago_config.yaml`)
 
 ```yaml
 archipelago:
@@ -36,7 +36,7 @@ archipelago:
 
 ### `PiShock`
 
-These are your credentials for PiShock.
+These are your credentials for PiShock.  (`pishock_config.yaml`)
 
 ```yaml
 pishock:
@@ -51,36 +51,40 @@ You can find these on your [PiShock dashboard](https://pishock.com/#/login).
 
 ### `devices`
 
-Define each PiShock-compatible device you want to use.
+Define each PiShock-compatible device you want to use.  (`pishock_config.yaml`)
 
 ```yaml
-devices:
-  Device-1:              
-    name: Device_name       # Device name can be anything you want
+device_profiles:
+  Device_1: # Device name can be anything you want       
     device_id: 12345        # this is the id of your PiShock device
     share_code: ShareCode   # this is the sharecode of The same PiShock device
-    mode: 2                 # 0 = activation, 1 = vibrate, 2 = beep
-    intensity: 100          # 0–100 (100 is max)
-    duration: 1000          # In milliseconds (1000ms = 1 second)
-# just copy the block under for every device you want, but dont forget the spaces.
-  Device-2:
+# just copy the block under for every device profile you want, but dont forget the spaces.
+  Device_2:
     name: Device_name        
     device_id: 12345        
     share_code: ShareCode   
-    mode: 2                 
-    intensity: 100          
-    duration: 1000          
+
+activation_profiles:
+  Beep:  # activation name can be anything you want.
+    mode: 2                 # 0 = activation, 1 = vibrate, 2 = beep
+    intensity: 100          # 0–100 (100 is max) (intensity is ignored for beep)
+    duration: 1000          # In milliseconds (1000ms = 1 second)
+# just copy the block under for every actication profile you want, but dont forget the spaces.
+  Vibrate:
+    mode: 1
+    intensity: 100
+    duration: 1000
 ```
 
-* **name:** Can be anything, but the name must match references in `deathlink`, `traps` and `otherChecks`.
-* You can add as many devices as needed by repeating the format under `devices:`.
-* **Important** when adding more devices, make sure `Device-(number)` dont have the same number with other devices as shown above with `Device-1` and `Device-2`
+* The names you use for devices listed in `deathlink`, `traps` and `otherChecks` is a combination of the device profile name and the activation profile name, like so. `Device_1Beep`, `Device_1Vibrate`, `Device_2Beep`, `Device_2Vibrate` .
+* You can add as many device and activation profiles as needed by repeating the format under `device_profiles:` and `activation_profiles:`.
+* **Important** when adding more device and activation profiles, make sure the names of each of the profiles are unique, such as `Device_1`, `Device_2`, `Beep`, `Vibrate`
 
 ---
 
 ### `deathlink/trapLink`
 
-Configure which devices activate when a *DeathLink* or/and *TrapLink* event occurs (shared player deaths/shared player traps).
+Configure which devices activate when a *DeathLink* or/and *TrapLink* event occurs (shared player deaths/shared player traps) (`archipelago_config.yaml`).
 
 ```yaml
 deathlink:
@@ -95,13 +99,13 @@ trapLink:
 
 * Set `activated` to `true` to enable DeathLink/trapLink or `false` to dsable it.
 * List all device names you want to activate (from the `devices` you created)  with a comma and space `, ` inbetween.
-* **Important:** Do not use the same device multiple times on the same link.
+* **Important:** Do not use the same device profile multiple times on the same link.
 
 ---
 
 ### `traps`
 
-Traps allow you to bind in-game checks (like item checks or Trap items) to your devices.
+Traps allow you to bind in-game checks (like item checks or Trap items) to your devices. (`archipelago_config.yaml`)
 
 ```yaml
 traps:
@@ -113,19 +117,27 @@ traps:
     name: Item_check-2
     for_self: false
     devices: [Device_name, Device_name_2]
+  trap-3:
+    names:                    # In this instance, you can sepcify multiple item check names that trigger a set of devices.
+      - Item_check-3
+      - Item_check-4
+      - Item_check-5
+    for_self: true
+    devices: [Device_name, Device_name_2]
 ```
 
 * The **name** must exactly match the item check name as it appears in the Archipelago client or game logic.
+*  You can specify a list of **item names** using the `names:` option instead of `name:`
 * **for_self** should be `true` if its an item that is for yourself, and `false` if the item check is for someone else
 * Device names must match entries in the `devices` section you created earlier.
-* You can assign multiple devices to one trap, or reuse devices across different traps, but you CAN NOT use the same device twice or more in one trap.
+* You can assign multiple devices to one trap, or reuse devices across different traps, but you CAN NOT use the same device profile twice or more in one trap.
 * you can add as many item checks as you want, but remember to have them under `traps:` and remember that `trap-(number)` needs to have a unique number
 
 ---
 
 ### `Other checks`
 
-**OtherChecks** lets you set up devices to activate on ALL other item checks that has something to do with you, that isnt already triggered by an existing item check from the traps section. 
+**OtherChecks** lets you set up devices to activate on ALL other item checks that has something to do with you, that isnt already triggered by an existing item check from the traps section.  (`archipelago_config.yaml`)
 
 ```yaml
 OtherChecks:
@@ -135,30 +147,36 @@ OtherChecks:
 ```
 * **activated** should be `true` if you want other items to activate the PiShock devices or `false`, if you dont want that.
 * **send/receive** should be `send` if you want only items you send to others to trigger the devices, `receive` if you want only items you receive to trigger the devices, or `all` if you want all items that has something to do with you to trigger the devices.
-* **devices** works like previously where you can not use the same device multiple times, and you need to have the device name be exactly the same as the one you created in that section.
+* **devices** works like previously where you can not use the same device profile multiple times, and you need to have the device name be exactly the same as the one you created in that section.
 
 ---
 
 ## Example:
 
+(`pishock_config.yaml`)
 ```yaml
-devices:
-  trap-1:
-    name: Belt
+device_profiles:
+  Belt:
     device_id: 12345
     share_code: ABCDEF1234
+
+activation_profiles:
+  Vibrate:
     mode: 1
     intensity: 75
     duration: 1500
 ```
 
+(`archipelago_config.yaml`)
 ```yaml
 traps:
   trap-1:
     name: Bee trap
     for_self: true
-    devices: [Belt]
+    devices: [BeltVibrate]
 ```
+
+* You can now duplicate (`archipelago_config.yaml`), customize it for each game. Alternate archipelago configuration yamls can be dragged and dropped onto the binary to use that configuration.
 
 ---
 

--- a/arc_connect.py
+++ b/arc_connect.py
@@ -162,7 +162,7 @@ async def check_for_items(cmd, name_map, pishock_client, Is_player):
                 print(f"Recieved item: {item_name} (ID {item_id})")
 
             else:
-                print(f"Sendt item: {item_name} (ID {item_id})")
+                print(f"Sent item: {item_name} (ID {item_id})")
             # activation time
             await check_for_traps(item_name, pishock_client, Is_player)
 

--- a/arc_connect.py
+++ b/arc_connect.py
@@ -116,11 +116,19 @@ async def archipelago_client(pishock_client):
             packet = json.loads(frame)
             for cmd in packet:
                 c = cmd.get("cmd")
-                
-                if c == "Bounced" or c == "TrapLink":
+                if c == "Bounced" or c == "TrapLink" or c == "DeathLink":
+                    t = cmd.get("tags", [])
                     d = cmd.get("data", {})
-                    print(f"TrapLink: {d.get('source')!r} sendt a {d.get('trap_name')!r}")
-                    await websocket2.send_activation(settings.trapLink_devices, pishock_client)
+                    #print(cmd)
+                    #print(t)
+                    #print(d)
+                    if "TrapLink" in t or c == "TrapLink":
+                        print(f"TrapLink: {d.get('source')!r} sent a {d.get('trap_name')!r}")
+                        await websocket2.send_activation(settings.trapLink_devices, pishock_client)
+                    if "DeathLink" in t or c == "DeathLink":
+                        print(f"DeathLink from {d.get('source')!r} because of {d.get('cause')!r}")
+                        await websocket2.send_activation(settings.Deathlink_devices, pishock_client)
+                
 
                 # when you get an item
                 elif c == "PrintJSON" and cmd.get("type") == "ItemSend":
@@ -142,11 +150,6 @@ async def archipelago_client(pishock_client):
                     for loc in new_locs:
                         seen_locations.add(loc)
                         await ws.send(json.dumps([{"cmd": "CheckLocation", "location": loc}]))
-
-                elif c == "Bounced" or c == "DeathLink":
-                    d = cmd.get("data", {})
-                    print(f"DeathLink from {d.get('source')!r} because of {d.get('cause')!r}")
-                    await websocket2.send_activation(settings.Deathlink_devices, pishock_client)
 
                 else:
                     #print(f"Other `{c}`: {cmd!r}")

--- a/archipelago_config.yaml
+++ b/archipelago_config.yaml
@@ -1,0 +1,39 @@
+# This is the configuration file for the program.
+# The guide is on Github under Readme
+# things with # infront is just a comment
+
+# archipelago important variables (change only the values after the colon :)
+archipelago:
+  room_code: 12345
+  name: ArchipelagoName
+  game: GameName
+  password: null
+
+# Deathlink settings
+deathlink:
+  activated: false
+  devices: []
+
+# Trap Link settings
+trapLink:
+  activated: false
+  devices: []
+
+# Archipelago Item/Trap Check Configuration
+traps:
+  trap-1:
+    name: Item_check_name
+    for_self: true
+    devices: []
+  trap-2:
+    names:
+      - Item_check_name_2
+      - Item_check_name_3
+    for_self: true
+    devices: []
+
+# All other items that comes from or goes to you
+OtherChecks:
+  activated: false
+  send/receive: all                      
+  devices: []

--- a/pishock_config.yaml
+++ b/pishock_config.yaml
@@ -8,7 +8,7 @@ pishock:
   api_key: API-Key
   client_id: 12345
 
-# PiShock devices:
+# PiShock device and activation profiles:
 device_profiles:
   Device_1:
     device_id: 12345

--- a/pishock_config.yaml
+++ b/pishock_config.yaml
@@ -1,0 +1,25 @@
+# This is the configuration file for the program.
+# The guide is on Github under Readme
+# things with # infront is just a comment
+
+# PiShock important variables (change only the values after the colon :)
+pishock:
+  username: PishockName
+  api_key: API-Key
+  client_id: 12345
+
+# PiShock devices:
+device_profiles:
+  Device_1:
+    device_id: 12345
+    share_code: ShareCode
+    
+activation_profiles:
+  Activation_1:
+    mode: 0
+    intensity: 100
+    duration: 1000
+
+# When specifying your devices in archipelago_config.yaml, 
+# you combine the desired device with the desired activation profile like so:
+# devices: [Device_1Activation_1, Device_2Activation_1], etc...

--- a/settings.py
+++ b/settings.py
@@ -36,21 +36,23 @@ devices             = pishock_config["devices"]
 server_port         = archipelago_config["archipelago"]["room_code"]
 archipelago_name    = archipelago_config["archipelago"]["name"]
 game                = archipelago_config["archipelago"]["game"]
-password            = archipelago_config["archipelago"]["password"]
+password            = archipelago_config["archipelago"].get("password", None)
 
 #deathlink variables:
-Deathlink_mode      = archipelago_config["deathlink"]["activated"]
-Deathlink_devices   = archipelago_config["deathlink"]["devices"]
+DeathLink           = archipelago_config.get("deathlink", {"activated": False, "devices": []})
+Deathlink_mode      = DeathLink.get("activated", False)
+Deathlink_devices   = DeathLink.get("devices", [])
 
 #trapLink variables:
-trapLink_mode       = archipelago_config["trapLink"]["activated"]
-trapLink_devices    = archipelago_config["trapLink"]["devices"]
+TrapLink            = archipelago_config.get("trapLink", {"activated": False, "devices": []})
+trapLink_mode       = TrapLink.get("activated", False)
+trapLink_devices    = TrapLink.get("devices", [])
 
 #Traps n items:
-traps               = archipelago_config["traps"]
+traps               = archipelago_config.get("traps", {})
 
 #other items:
-otherChecks         = archipelago_config["OtherChecks"]
+otherChecks         = archipelago_config.get("OtherChecks", {"activated": False, "send/receive": "all", "devices": []})
 
 def fetch_user_id() -> str:
     """

--- a/settings.py
+++ b/settings.py
@@ -8,39 +8,49 @@ if getattr(sys, 'frozen', False):
 else:
     current_dir = os.path.dirname(os.path.abspath(__file__))
 
-config_path = os.path.join(current_dir, "config.yaml")
+if len(sys.argv) > 1:
+    archipelago_config_path = sys.argv[1]
+else:
+    archipelago_config_path = os.path.join(current_dir, "archipelago_config.yaml")
+    
+pishock_config_path = os.path.join(current_dir, "pishock_config.yaml")
 
 # Load YAML
-with open(config_path, 'r') as file:
-    config = yaml.safe_load(file)
-
-#Archipelago variables:
-server_port         = config["archipelago"]["room_code"]
-archipelago_name    = config["archipelago"]["name"]
-game                = config["archipelago"]["game"]
-password            = config["archipelago"]["password"]
-
+with open(pishock_config_path, 'r') as file:
+    pishock_config = yaml.safe_load(file)
+    
+with open(archipelago_config_path, 'r') as file:
+    archipelago_config = yaml.safe_load(file)
+    
+## PiShock configuration data
 #PiShock variables:
-pishock_name        = config["pishock"]["username"]
-api_key             = config["pishock"]["api_key"]
-hub_client_id       = config["pishock"]["client_id"]
+pishock_name        = pishock_config["pishock"]["username"]
+api_key             = pishock_config["pishock"]["api_key"]
+hub_client_id       = pishock_config["pishock"]["client_id"]
 
 #devices:
-devices             = config["devices"]
+devices             = pishock_config["devices"]
+
+## Archipelago configuration data
+#Archipelago variables:
+server_port         = archipelago_config["archipelago"]["room_code"]
+archipelago_name    = archipelago_config["archipelago"]["name"]
+game                = archipelago_config["archipelago"]["game"]
+password            = archipelago_config["archipelago"]["password"]
 
 #deathlink variables:
-Deathlink_mode      = config["deathlink"]["activated"]
-Deathlink_devices   = config["deathlink"]["devices"]
+Deathlink_mode      = archipelago_config["deathlink"]["activated"]
+Deathlink_devices   = archipelago_config["deathlink"]["devices"]
 
 #trapLink variables:
-trapLink_mode       = config["trapLink"]["activated"]
-trapLink_devices    = config["trapLink"]["devices"]
+trapLink_mode       = archipelago_config["trapLink"]["activated"]
+trapLink_devices    = archipelago_config["trapLink"]["devices"]
 
 #Traps n items:
-traps               = config["traps"]
+traps               = archipelago_config["traps"]
 
 #other items:
-otherChecks         = config["OtherChecks"]
+otherChecks         = archipelago_config["OtherChecks"]
 
 def fetch_user_id() -> str:
     """

--- a/settings.py
+++ b/settings.py
@@ -29,7 +29,24 @@ api_key             = pishock_config["pishock"]["api_key"]
 hub_client_id       = pishock_config["pishock"]["client_id"]
 
 #devices:
-devices             = pishock_config["devices"]
+devices             = pishock_config.get("devices", {})
+device_profiles     = pishock_config.get("device_profiles", {})
+activation_profiles = pishock_config.get("activation_profiles", {})
+
+if not devices and device_profiles and activation_profiles:
+    # Build all possible device combinations from device_profiles and activation profiles, one time.
+    for device_key, device_value in device_profiles.items():
+        for activation_key, activation_value in activation_profiles.items():
+            device_name = f"{device_key}{activation_key}"
+            devices[device_name] = {
+                "device_id": device_value["device_id"],
+                "share_code": device_value["share_code"],
+                "mode": activation_value["mode"],
+                "intensity": activation_value["intensity"],
+                "duration": activation_value["duration"]
+            }
+
+
 
 ## Archipelago configuration data
 #Archipelago variables:

--- a/websocket2.py
+++ b/websocket2.py
@@ -157,7 +157,7 @@ class PiShockClient:
         all_devices = settings.devices
         return [
             [
-                device["name"],
+                device_name,
                 device["device_id"],
                 device["share_code"],
                 device["mode"],
@@ -165,8 +165,8 @@ class PiShockClient:
                 device["duration"]
             ]
             for name in device_names
-            for device in all_devices.values()
-            if device.get("name") == name
+            for device_name, device in all_devices.items()
+            if device_name == name
         ]
     
 async def send_activation(device_names: list[str], client: PiShockClient):


### PR DESCRIPTION
* Break out `config.yaml` into `pishock_config.yaml` and `archipelago_config.yaml`
  *  `pishocK_config.yaml is the home of pishock account credentials, pishock device profiles, and pishock activation profiles.
  * `achipelago_config.yaml` is the home of anything done archipelago side.
* Correctly decode Bounce Packets into DeathLink and TrapLink packets.
* Fix a typo
* Break out devices in pishock_config.yaml into device_profiles and activation_profiles.
* Names now derived from the key names of each device and activation profile.  An overall device name is a combination of the device profile name, and activation profile name,
* OtherChecks made to always work even when the traps section is blank, and OtherChecks is activated.
* A trap entry now has a possibility to specify multiple items in that section that can activate a given set of device/activation profiles.
* Command line / Drag and drop possibility to load alternate archipelago configuration yamls.